### PR TITLE
add user facing canvas API and chnage color

### DIFF
--- a/src/ComputationalArt2/CACanvas.class.st
+++ b/src/ComputationalArt2/CACanvas.class.st
@@ -52,49 +52,17 @@ CACanvas >> clearImage: aForm [
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'Tyron Franzke 6/5/2024 13:17'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:01'
 }
 CACanvas >> colorAt: aPosition [
-
-	^ self form colorAt: aPosition.
+	^ CARGB newFrom: (self form colorAt: aPosition).
 ]
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'Tyron Franzke 6/5/2024 12:52'
-}
-CACanvas >> colorsFrom: aStartPosition to: anEndPosition [
-
-	| colorsMatrix endX endY startX startY |
-	startX := aStartPosition x.
-	startY := aStartPosition y.
-	endX := anEndPosition x.
-	endY := anEndPosition y.
-
-	colorsMatrix := Array new: endX - startX + 1.
-    
-	 (startX to: endX) do: [ :x |
-		| column |
-		column := Array new: endY - startY + 1.
-	        
-		(startY to: endY) do: [ :y |
-	            | color |
-	            color := self colorAt: x@y.
-	            column at: (y - startY + 1) put: color.
-	        ].
-	        
-	        colorsMatrix at: (x - startX + 1) put: column.
-		].
-	
-	^ colorsMatrix.
-]
-
-{
-	#category : #api,
-	#'squeak_changestamp' : 'Tyron Franzke 6/5/2024 13:31'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:05'
 }
 CACanvas >> commit [
-	
 	stableCanvas setForm: stagedCanvas form deepCopy.
 ]
 
@@ -131,9 +99,9 @@ CACanvas >> depth: aDepth [
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'iss 6/12/2024 18:35'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:06'
 }
-CACanvas >> drawCircleOutlineAt: center radius: radius color: aColor [
+CACanvas >> drawCircleOutlineAt: center radius: radius color: aCARGB [
 	| angle stepAngle prevPoint x y |
 	stepAngle := (2 * Float pi) / 100.
 	prevPoint := center + (radius @ 0).
@@ -142,61 +110,78 @@ CACanvas >> drawCircleOutlineAt: center radius: radius color: aColor [
 		angle := i * stepAngle.
 		x := center x + (radius * (angle cos)).
 		y := center y + (radius * (angle sin)).
-		self drawLine: prevPoint to: (x @ y) width: 1 color: aColor.
+		self drawLine: prevPoint to: (x @ y) width: 1 color: aCARGB.
 		prevPoint := (x @ y).
 		].
 ]
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 21:19'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:06'
 }
-CACanvas >> drawLine: aStartPoint to: anEndPoint width: aLineWidth color: aColor [
+CACanvas >> drawLine: aStartPoint to: anEndPoint width: aLineWidth color: aCARGB [
 
 	stagedCanvas line: aStartPoint to: anEndPoint
-		width: aLineWidth color: aColor.
+		width: aLineWidth color: aCARGB.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:06'
+}
+CACanvas >> drawOutlineOfRect: rect withColor: aCARGB [
+    | topEdge bottomEdge leftEdge rightEdge borderWidth |
+    borderWidth := 1. 
+    topEdge := Rectangle origin: rect topLeft extent: rect width @ borderWidth.
+    bottomEdge := Rectangle origin: rect bottomLeft - (0 @ borderWidth) extent: rect width @ borderWidth.
+    leftEdge := Rectangle origin: rect topLeft extent: borderWidth @ rect height.
+    rightEdge := Rectangle origin: rect topRight - (borderWidth @ 0) extent: borderWidth @ rect height.
+
+    self drawRect: topEdge color: aCARGB.
+    self drawRect: bottomEdge color: aCARGB.
+    self drawRect: leftEdge color: aCARGB.
+    self drawRect: rightEdge color: aCARGB.
 ]
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'Tyron Franzke 6/5/2024 13:39'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:06'
 }
-CACanvas >> drawPoint: aPoint color: aColor [
-
-	stagedCanvas point: aPoint color: aColor.
+CACanvas >> drawPoint: aPoint color: aCARGB [
+	stagedCanvas point: aPoint color: aCARGB.
 ]
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'Tyron Franzke 6/5/2024 13:36'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:06'
 }
-CACanvas >> drawRect: aRectangle color: aColor [
+CACanvas >> drawRect: aRectangle color: aCARGB [
 
-	stagedCanvas fillRectangle: aRectangle color: aColor.
+	stagedCanvas fillRectangle: aRectangle color: aCARGB.
 ]
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'Tyron Franzke 6/5/2024 13:36'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:06'
 }
-CACanvas >> drawRect: aStartPoint to: anEndPoint color: aColor [
+CACanvas >> drawRect: aStartPoint to: anEndPoint color: aCARGB [
 
 	stagedCanvas fillRectangle:
-		(Rectangle origin: aStartPoint corner: anEndPoint) color: aColor.
+		(Rectangle origin: aStartPoint corner: anEndPoint) color: aCARGB.
 ]
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'iss 6/12/2024 18:33'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:07'
 }
-CACanvas >> fillCircleAt: center radius: radius color: aColor [
+CACanvas >> fillCircleAt: center radius: radius color: aCARGB [
 	| dx dy |
 	(center x - radius to: center x + radius) do: [:x |
 		(center y - radius to: center y + radius) do: [:y |
 			dx := x - center x.
 			dy := y - center y.
 			((dx * dx) + (dy * dy) <= (radius * radius)) ifTrue: [
-				self drawPoint: (x @ y) color: aColor.
+				self drawPoint: (x @ y) color: aCARGB.
 				].
 			].
 		].
@@ -204,22 +189,20 @@ CACanvas >> fillCircleAt: center radius: radius color: aColor [
 
 {
 	#category : #api,
-	#'squeak_changestamp' : 'iss 6/11/2024 16:49'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 17:01'
 }
-CACanvas >> fillFrom: startPoint withColor: aColor [
+CACanvas >> fillFrom: startPoint withColor: aCARGB [
 
 	| stack oldColor |
-	oldColor := self colorAt: startPoint.
-	(oldColor = aColor) ifTrue: [ ^self ].
-	
+	oldColor  := self colorAt: startPoint.
+	oldColor = aCARGB ifTrue: [ ^self ].
 	stack := OrderedCollection new.
 	stack add: startPoint.
-	
 	[ stack isEmpty ] whileFalse: [
 		| point neighbors |
 		point := stack removeLast.
 		(self colorAt: point) = oldColor ifTrue: [
-			self drawPoint: point color: aColor.
+			self drawPoint: point color: aCARGB.
 			neighbors := { point + (1@0). point - (1@0). point + (0@1). point - (0@1) }.
 			neighbors do: [ :neighbor |
 				(self isInBounds: neighbor) ifTrue: [ stack add: neighbor ].

--- a/src/ComputationalArt2/CACanvasAPI.class.st
+++ b/src/ComputationalArt2/CACanvasAPI.class.st
@@ -1,0 +1,196 @@
+Class {
+	#name : #CACanvasAPI,
+	#superclass : #Object,
+	#instVars : [
+		'canvas',
+		'strokeWidth',
+		'strokeRGB',
+		'fillRGB'
+	],
+	#category : #ComputationalArt2
+}
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:16'
+}
+CACanvasAPI >> fillCircle: aPoint radius: aNumber [
+	canvas fillCircleAt: aPoint radius: aNumber color: fillRGB.
+	
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 14:39'
+}
+CACanvasAPI >> fillR:r G: g B: b [
+	self fillRGB: (CARGB r: r g: g b: b).
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 14:00'
+}
+CACanvasAPI >> fillRGB [
+	^fillRGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:24'
+}
+CACanvasAPI >> fillRGB: aCARGB [
+	fillRGB := aCARGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:34'
+}
+CACanvasAPI >> fillRect: start extent: size [
+	canvas drawRect: start to: (start + size) color: fillRGB.
+	
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:34'
+}
+CACanvasAPI >> fillRect: start to: end [
+	canvas drawRect: start to: end color: fillRGB.
+	
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:54'
+}
+CACanvasAPI >> height [
+	^canvas height.
+]
+
+{
+	#category : #private,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:34'
+}
+CACanvasAPI >> initialize [
+	self strokeRGB: (CARGB black).
+	self fillRGB: (CARGB black).
+	self strokeWidth: 1.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:55'
+}
+CACanvasAPI >> pixelsDo: aBlock [
+	0 to: (self width - 1) do: [:y|
+		0 to: (self height - 1) do: [:x|
+			aBlock value: x value: y.].].
+]
+
+{
+	#category : #private,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 13:54'
+}
+CACanvasAPI >> privateCanvas: aCACanvas [
+	canvas := aCACanvas.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:59'
+}
+CACanvasAPI >> rgbAt: aPoint [
+	| p |
+	p := (aPoint x min: (self width) max: 0)@(aPoint y min: (self height) max: 0).
+	^canvas colorAt: aPoint.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:34'
+}
+CACanvasAPI >> rgbAt: aPoint put: aCARGB [
+	^canvas drawPoint: aPoint color: aCARGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:15'
+}
+CACanvasAPI >> strokeCircle: aPoint radius: aNumber [
+	canvas drawCircleOutlineAt: aPoint radius: aNumber color: strokeRGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:28'
+}
+CACanvasAPI >> strokeLine: start to: end [
+	^canvas drawLine: start to: end width: strokeWidth color: strokeRGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 14:39'
+}
+CACanvasAPI >> strokeR:r G: g B: b [
+	self strokeRGB: (CARGB r: r g: g b: b).
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 14:00'
+}
+CACanvasAPI >> strokeRGB [
+	^strokeRGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:24'
+}
+CACanvasAPI >> strokeRGB: aCARGB [
+	strokeRGB := aCARGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:36'
+}
+CACanvasAPI >> strokeRect: start extent: size [
+	canvas drawOutlineOfRect: (start extent: size) withColor: strokeRGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:38'
+}
+CACanvasAPI >> strokeRect: start to: end [
+	canvas drawOutlineOfRect: (start corner: end) withColor: strokeRGB.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 13:56'
+}
+CACanvasAPI >> strokeWidth [
+	^strokeWidth.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 13:55'
+}
+CACanvasAPI >> strokeWidth: aNumber [
+	strokeWidth := aNumber.
+]
+
+{
+	#category : #API,
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:40'
+}
+CACanvasAPI >> width [
+	^canvas width.
+]

--- a/src/ComputationalArt2/CACanvasContainer.class.st
+++ b/src/ComputationalArt2/CACanvasContainer.class.st
@@ -134,7 +134,7 @@ CACanvasContainer >> handlesMouseWheel: anEvent [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/5/2024 19:12'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:40'
 }
 CACanvasContainer >> initialize [
 	super initialize.
@@ -148,14 +148,6 @@ CACanvasContainer >> initialize [
 	
 	caCanvas := CACanvas new: 100 height: 100 depth: 32.
 	caCanvas create.
-	
-	caCanvas clearColor: Color green.
-	
-	0 to: 99 do: [ :y |
-		0 to: 99 do: [ :x |
-			caCanvas drawPoint: x@y color: Color random.
-			].
-		].
 	
 	imageMorph := ImageMorph new image: caCanvas form.
 	imageMorph position: canvasOffset.

--- a/src/ComputationalArt2/CACircleTool.class.st
+++ b/src/ComputationalArt2/CACircleTool.class.st
@@ -38,7 +38,7 @@ CACircleTool class >> toolName [
 
 {
 	#category : #drawing,
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 20:13'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:52'
 }
 CACircleTool >> drawCircleFrom: startPoint to: endPoint on: aCACanvasContainer [
 	| center radius caWindow |
@@ -47,9 +47,9 @@ CACircleTool >> drawCircleFrom: startPoint to: endPoint on: aCACanvasContainer [
 	
 	caWindow := aCACanvasContainer caWindow.
 	caWindow toolFill ifTrue: [
-		aCACanvasContainer canvas fillCircleAt: center radius: radius color: caWindow secondaryColor morphicColor.].
+		aCACanvasContainer canvas fillCircleAt: center radius: radius color: caWindow secondaryColor.].
 	caWindow toolStroke ifTrue: [
-		aCACanvasContainer canvas drawCircleOutlineAt: center radius: radius color: caWindow primaryColor morphicColor.].
+		aCACanvasContainer canvas drawCircleOutlineAt: center radius: radius color: caWindow primaryColor.].
 ]
 
 {

--- a/src/ComputationalArt2/CAColorPickerWindow.class.st
+++ b/src/ComputationalArt2/CAColorPickerWindow.class.st
@@ -49,7 +49,7 @@ CAColorPickerWindow >> colorSelected: aColor [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 21:21'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:50'
 }
 CAColorPickerWindow >> initialize [
 	| vBox hBox hBoxRed hBoxGreen hBoxBlue hBoxHue hBoxSaturation hBoxValue cancelButton hBoxButtons acceptButton |
@@ -76,12 +76,15 @@ CAColorPickerWindow >> initialize [
 	
 	hueTextMorph := CAIntegerTextMorph new minValue: 0; maxValue: 255.
 	hueTextMorph hResizing: #spaceFill.
+	hueTextMorph actionBlock: [:num | hsv selectedColor: (Color h: (num / 255.0 * 360) s: hsv selectedColor saturation v: hsv selectedColor brightness).].
 	
 	saturationTextMorph := CAIntegerTextMorph new minValue: 0; maxValue: 255.
 	saturationTextMorph hResizing: #spaceFill.
+	saturationTextMorph actionBlock: [:num | hsv selectedColor: (Color h: hsv selectedColor hue s: (num / 255.0) v: hsv selectedColor brightness).].
 	
 	valueTextMorph := CAIntegerTextMorph new minValue: 0; maxValue: 255.
 	valueTextMorph hResizing: #spaceFill.
+	valueTextMorph actionBlock: [:num | hsv selectedColor: (Color h: hsv selectedColor hue s: hsv selectedColor saturation v: (num / 255.0)).].
 	
 	hBoxRed := CAWindow createHBox.
 	hBoxRed addMorph: redTextMorph;
@@ -169,11 +172,11 @@ CAColorPickerWindow >> paneColor [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 19:30'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:43'
 }
-CAColorPickerWindow >> startColor: aCAColor [
+CAColorPickerWindow >> startColor: aCARGB [
 	| morpicColor |
-	morpicColor := aCAColor morphicColor.
+	morpicColor := aCARGB morphicColor.
 	self colorSelected: morpicColor.
-	hsv selectColor: morpicColor.
+	hsv selectedColor: morpicColor.
 ]

--- a/src/ComputationalArt2/CAFloodFillTool.class.st
+++ b/src/ComputationalArt2/CAFloodFillTool.class.st
@@ -29,13 +29,13 @@ CAFloodFillTool class >> toolName [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 20:32'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:58'
 }
 CAFloodFillTool >> handleMouseDown: anEvent on: aCACanvasContainer [
 	| startPoint |
 	aCACanvasContainer canvas saveState.
 	startPoint := aCACanvasContainer getPixelPosition: anEvent position.
 	
-	aCACanvasContainer canvas fillFrom: startPoint withColor: aCACanvasContainer caWindow primaryColor morphicColor.
+	aCACanvasContainer canvas fillFrom: startPoint withColor: aCACanvasContainer caWindow primaryColor.
 	aCACanvasContainer updateForm.
 ]

--- a/src/ComputationalArt2/CALineTool.class.st
+++ b/src/ComputationalArt2/CALineTool.class.st
@@ -43,7 +43,7 @@ CALineTool >> handleMouseDown: anEvent on: aCACanvasContainer [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 21:15'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:58'
 }
 CALineTool >> handleMouseMove: anEvent on: aCACanvasContainer [
 
@@ -51,19 +51,19 @@ CALineTool >> handleMouseMove: anEvent on: aCACanvasContainer [
 		caWindow := aCACanvasContainer caWindow.
 		aCACanvasContainer canvas reset.
 		endPoint := aCACanvasContainer getPixelPosition: anEvent position.
-		aCACanvasContainer canvas drawLine: startPoint to: endPoint width: caWindow toolStrokeWidth color: caWindow primaryColor morphicColor.
+		aCACanvasContainer canvas drawLine: startPoint to: endPoint width: caWindow toolStrokeWidth color: caWindow primaryColor.
 		aCACanvasContainer updateForm.].
 ]
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 21:16'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:26'
 }
 CALineTool >> handleMouseUp: anEvent on: aCACanvasContainer [
 	| endPoint caWindow |
 	endPoint := aCACanvasContainer getPixelPosition: anEvent position.
 	caWindow := aCACanvasContainer caWindow.
-	aCACanvasContainer canvas drawLine: startPoint to: endPoint width: caWindow toolStrokeWidth color: caWindow primaryColor morphicColor.
+	aCACanvasContainer canvas drawLine: startPoint to: endPoint width: caWindow toolStrokeWidth color: caWindow primaryColor.
 	startPoint := nil.
 	aCACanvasContainer canvas commit.
 	aCACanvasContainer updateForm.

--- a/src/ComputationalArt2/CAPenTool.class.st
+++ b/src/ComputationalArt2/CAPenTool.class.st
@@ -32,10 +32,10 @@ CAPenTool class >> toolName [
 
 {
 	#category : #'event handling',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 20:16'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:50'
 }
 CAPenTool >> drawAt: aPoint on: aCACanvasContainer [
-	aCACanvasContainer canvas drawPoint: aPoint color: aCACanvasContainer caWindow primaryColor morphicColor.
+	aCACanvasContainer canvas drawPoint: aPoint color: aCACanvasContainer caWindow primaryColor.
 
 ]
 
@@ -63,10 +63,11 @@ CAPenTool >> handleMouseMove: anEvent on: aCACanvasContainer [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'iss 6/12/2024 17:41'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:06'
 }
 CAPenTool >> handleMouseUp: anEvent on: aCACanvasContainer [
 	isDrawing := false.
+	aCACanvasContainer canvas commit.
 ]
 
 {

--- a/src/ComputationalArt2/CARGB.class.st
+++ b/src/ComputationalArt2/CARGB.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #CARGB,
-	#superclass : #Object,
+	#superclass : #Color,
 	#instVars : [
 		'red',
 		'green',
@@ -11,10 +11,58 @@ Class {
 
 {
 	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:29'
+}
+CARGB class >> black [
+	^CARGB r: 0 g: 0 b: 0.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:19'
+}
+CARGB class >> blue [
+	^CARGB r: 0 g: 0 b: 255.
+]
+
+{
+	#category : #'as yet unclassified',
 	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 19:25'
 }
 CARGB class >> chanelTo8Bit: aNumber [
 	^(((aNumber * 256.0) floor) min: 255).
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:19'
+}
+CARGB class >> cyan [
+	^CARGB r: 0 g: 255 b: 255.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:21'
+}
+CARGB class >> gray [
+	^CARGB r: 127 g: 127 b: 127.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:19'
+}
+CARGB class >> green [
+	^CARGB r: 0 g: 255 b: 0.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:20'
+}
+CARGB class >> magenta [
+	^CARGB r: 255 g: 0 b: 255.
 ]
 
 {
@@ -32,10 +80,53 @@ CARGB class >> newFrom: aColor [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 19:40'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:56'
+}
+CARGB class >> r: r g: g b: b [
+	| rgb |
+	rgb := self basicNew.
+	rgb red: r; green: g; blue: b.
+	^rgb.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:18'
+}
+CARGB class >> random [
+	^CARGB r: (255 random) g: (255 random) b: (255 random).
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:19'
+}
+CARGB class >> red [
+	^CARGB r: 255 g: 0 b: 0.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:20'
+}
+CARGB class >> white [
+	^CARGB r: 255 g: 255 b: 255.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:20'
+}
+CARGB class >> yellow [
+	^CARGB r: 255 g: 255 b: 0.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 15:30'
 }
 CARGB >> = aCARGB [
-	^red = aCARGB red and: green = aCARGB green and blue = aCARGB blue.
+	^(red = aCARGB red) and: (green = aCARGB green) and: (blue = aCARGB blue).
 	
 ]
 
@@ -83,10 +174,25 @@ CARGB >> initialize [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 19:11'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:27'
 }
 CARGB >> morphicColor [
-	^Color r: red / 255.0 g: green / 255.0 b: blue / 255.0.
+	^Color r: red /255.0 g: green / 255.0 b: blue / 255.0.
+]
+
+{
+	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:46'
+}
+CARGB >> pixelValueForDepth: d [
+	| val |
+	d = 32 ifTrue: [
+		 val :=	((red bitShift: 16) bitAnd: 16rFF0000) bitOr:
+				(((green bitShift: 8) bitAnd: 16rFF00) bitOr:
+				((blue bitShift: 0) bitAnd: 16rFF)).
+		^16rFF000000 + val.].
+	self error: 'unknown pixel depth: ', d printString.
+
 ]
 
 {

--- a/src/ComputationalArt2/CARectangleTool.class.st
+++ b/src/ComputationalArt2/CARectangleTool.class.st
@@ -38,25 +38,7 @@ CARectangleTool class >> toolName [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Halfil 6/12/2024 21:58'
-}
-CARectangleTool >> drawOutlineOfRect: rect on: aCACanvasContainer withColor: color [
-    | topEdge bottomEdge leftEdge rightEdge borderWidth |
-    borderWidth := 1. 
-    topEdge := Rectangle origin: rect topLeft extent: rect width @ borderWidth.
-    bottomEdge := Rectangle origin: rect bottomLeft - (0 @ borderWidth) extent: rect width @ borderWidth.
-    leftEdge := Rectangle origin: rect topLeft extent: borderWidth @ rect height.
-    rightEdge := Rectangle origin: rect topRight - (borderWidth @ 0) extent: borderWidth @ rect height.
-
-    aCACanvasContainer canvas drawRect: topEdge color: color.
-    aCACanvasContainer canvas drawRect: bottomEdge color: color.
-    aCACanvasContainer canvas drawRect: leftEdge color: color.
-    aCACanvasContainer canvas drawRect: rightEdge color: color.
-]
-
-{
-	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 20:26'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:58'
 }
 CARectangleTool >> drawRectangleFrom: startPoint to: endPoint on: aCACanvasContainer [
 	| topLeft bottomRight width height rect caWindow |
@@ -68,10 +50,10 @@ CARectangleTool >> drawRectangleFrom: startPoint to: endPoint on: aCACanvasConta
 	rect := Rectangle origin: topLeft extent: width @ height.
 
 	caWindow toolFill ifTrue: [
-		aCACanvasContainer canvas drawRect: rect color: caWindow secondaryColor morphicColor.].
+		aCACanvasContainer canvas drawRect: rect color: caWindow secondaryColor.].
 
 	caWindow toolStroke ifTrue: [
-		self drawOutlineOfRect: rect on: aCACanvasContainer withColor: caWindow primaryColor morphicColor.].
+		aCACanvasContainer canvas drawOutlineOfRect: rect withColor: caWindow primaryColor.].
 ]
 
 {

--- a/src/ComputationalArt2/CAResetCanvasTool.class.st
+++ b/src/ComputationalArt2/CAResetCanvasTool.class.st
@@ -29,10 +29,10 @@ CAResetCanvasTool class >> toolName [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 20:31'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 16:59'
 }
 CAResetCanvasTool >> handleMouseDown: anEvent on: aCACanvasContainer [
-	aCACanvasContainer canvas clearColor: aCACanvasContainer caWindow primaryColor morphicColor.
+	aCACanvasContainer canvas clearColor: aCACanvasContainer caWindow primaryColor.
 	aCACanvasContainer canvas commit.
 	aCACanvasContainer updateForm.
 ]

--- a/src/ComputationalArt2/CAResetFeature.class.st
+++ b/src/ComputationalArt2/CAResetFeature.class.st
@@ -10,6 +10,18 @@ Class {
 
 {
 	#category : #'as yet unclassified',
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:23'
+}
+CAResetFeature class >> executeFeature: aCAWindow [
+	|  canvasContainer |
+	canvasContainer := aCAWindow canvasContainer.
+	canvasContainer canvas reset.
+	canvasContainer updateForm.
+	
+]
+
+{
+	#category : #'as yet unclassified',
 	#'squeak_changestamp' : 'Yoan Tchorenev 6/6/2024 23:33'
 }
 CAResetFeature class >> featureName [

--- a/src/ComputationalArt2/CAStartFeature.class.st
+++ b/src/ComputationalArt2/CAStartFeature.class.st
@@ -10,12 +10,16 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'KH 6/22/2024 16:29'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 14:33'
 }
 CAStartFeature class >> executeFeature: aCAWindow [
-	| block |
+	| block canvasAPI canvas |
+	canvas := aCAWindow canvasContainer canvas.
+	canvas reset.
 	block := Compiler evaluate: '[:canvas | ', aCAWindow scriptField text,']'.
-	block value: aCAWindow canvasContainer canvas.
+	canvasAPI := CACanvasAPI new.
+	canvasAPI privateCanvas: canvas.
+	block value: canvasAPI.
 	
 	aCAWindow canvasContainer updateForm.
 ]

--- a/src/ComputationalArt2/CAToolContainer.class.st
+++ b/src/ComputationalArt2/CAToolContainer.class.st
@@ -12,7 +12,7 @@ Class {
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 21:13'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 19:41'
 }
 CAToolContainer class >> create: aCAWindow [
 	
@@ -40,6 +40,7 @@ CAToolContainer class >> create: aCAWindow [
 	secondaryForm fillColor: aCAWindow secondaryColor morphicColor.
 	secondaryColorButton := CAIconButton newFrom: secondaryForm onClick: [ | colorPicker |
 		colorPicker := CAColorPickerWindow create.
+		colorPicker startColor: aCAWindow secondaryColor.
 		colorPicker onAccept: [:aCARGB |
 			aCAWindow secondaryColor: aCARGB.
 			secondaryForm fillColor: aCARGB morphicColor.
@@ -50,6 +51,7 @@ CAToolContainer class >> create: aCAWindow [
 	primaryForm fillColor: aCAWindow primaryColor morphicColor.
 	primaryColorButton := CAIconButton newFrom: primaryForm onClick: [ | colorPicker |
 		colorPicker := CAColorPickerWindow create.
+		colorPicker startColor: aCAWindow primaryColor.
 		colorPicker onAccept: [:aCARGB |
 			aCAWindow primaryColor: aCARGB.
 			primaryForm fillColor: aCARGB morphicColor.

--- a/src/ComputationalArt2/CAWindow.class.st
+++ b/src/ComputationalArt2/CAWindow.class.st
@@ -335,7 +335,7 @@ CAWindow >> canvasContainer: aCanvasContainer [
 
 {
 	#category : #'as yet unclassified',
-	#'squeak_changestamp' : 'Yoan Tchorenev 6/18/2024 19:59'
+	#'squeak_changestamp' : 'Yoan Tchorenev 6/23/2024 18:28'
 }
 CAWindow >> initialize [
 	super initialize.
@@ -343,8 +343,8 @@ CAWindow >> initialize [
 	toolFill := false.
 	toolStroke := true.
 	toolStrokeWidth := 1.
-	primaryColor := CARGB newFrom: Color black.
-	secondaryColor := CARGB newFrom: Color white.
+	primaryColor := CARGB black.
+	secondaryColor := CARGB white.
 ]
 
 {


### PR DESCRIPTION
+ We now must use the CARGB colors because the standard Color class can not store black (0,0,0), which is bad for floodFill and generally bad.
+ The user facing scripting canvas API now works more like a state machine where certain aspects can be set (fill color, stroke color, stroke width).